### PR TITLE
Task 33 -- meta variables PoC

### DIFF
--- a/dummy-api/src/test/kotlin/dummy_api/IntegrationTest.kt
+++ b/dummy-api/src/test/kotlin/dummy_api/IntegrationTest.kt
@@ -82,9 +82,7 @@ class IntegrationTest(
 
     @Test
     @TestFile("a-test.json")
-    fun `can create dummy ALT`() {
-
-    }
+    fun `can create dummy ALT`() {}
 
     @Test
     @TestFile("secret.json")
@@ -93,4 +91,8 @@ class IntegrationTest(
     @Test
     @TestFile("multi-step.json")
     fun `can retrieve dummy (2)`() {}
+
+    @Test
+    @TestFile("meta-variable.json")
+    fun `can use meta variables`() {}
 }

--- a/dummy-api/src/test/resources/postman/meta-variable.json
+++ b/dummy-api/src/test/resources/postman/meta-variable.json
@@ -1,0 +1,68 @@
+{
+	"info": {
+		"_postman_id": "b399b76d-b93d-4b9d-8304-1af0854225b4",
+		"name": "a-test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "46030483",
+		"_collection_link": "https://bitknot-6797149.postman.co/workspace/bitknot's-Workspace~004a6a44-0266-41d7-8482-6e9679410bc8/collection/46030483-b399b76d-b93d-4b9d-8304-1af0854225b4?action=share&source=collection_link&creator=46030483"
+	},
+	"item": [
+		{
+			"name": "create dummy",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const response = {",
+							"    \"response\": 201,",
+							"    \"content\" : {",
+							"        \"id\": \"{{any}}\",",
+							"        \"name\": \"Bob\"",
+							"    }",
+							"}"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "a",
+						"value": "a",
+						"type": "text"
+					},
+					{
+						"key": "b",
+						"value": "b",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"name\": \"Bob\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/dummy",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"dummy"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/lib/src/main/kotlin/com/github/bitknot_project/progressive_testing/ProgressiveTestingExtension.kt
+++ b/lib/src/main/kotlin/com/github/bitknot_project/progressive_testing/ProgressiveTestingExtension.kt
@@ -49,10 +49,8 @@ class ProgressiveTestingExtension : BeforeTestExecutionCallback {
         builder.baseUri(step.request.url)
 
         step.request.body?.let { builder.body(it) }
-        val typedHeaders =
-            step.request.headers.map { Header(it.key, it.value) }
 
-        builder.headers(Headers(typedHeaders))
+        builder.headers(Headers(step.request.headers))
         builder.contentType(ContentType.JSON)
         builder.accept(ContentType.JSON)
 
@@ -114,7 +112,7 @@ class ProgressiveTestingExtension : BeforeTestExecutionCallback {
             val headers = headersNode.associate {
                 it.requiredAt("/key").asText() to it.requiredAt("/value")
                     .asText()
-            }
+            }.map { (k, v) -> Header(k, v) }
 
             val url = entry.requiredAt("/request/url/raw").asText()
             val body =

--- a/lib/src/main/kotlin/com/github/bitknot_project/progressive_testing/ProgressiveTestingExtension.kt
+++ b/lib/src/main/kotlin/com/github/bitknot_project/progressive_testing/ProgressiveTestingExtension.kt
@@ -9,7 +9,7 @@ import io.restassured.RestAssured.given
 import io.restassured.http.ContentType
 import io.restassured.http.Header
 import io.restassured.http.Headers
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import java.io.FileInputStream
@@ -61,12 +61,47 @@ class ProgressiveTestingExtension : BeforeTestExecutionCallback {
                 response.then().statusCode(expectedStatusCode.asInt())
             }
 
-            val expectedBody = it.expectedResponse.at("/content")
-            if (!expectedBody.isMissingNode) {
-                val typedBody = response.body.`as`(JsonNode::class.java)
-                assertEquals(expectedBody, typedBody)
+            val expected = it.expectedResponse.at("/content")!!
+            if (!expected.isMissingNode) {
+                val actual =
+                    response.body.`as`(JsonNode::class.java) as JsonNode
+
+                val fieldAssertions = createFieldAssertions(expected, actual)
+                fieldAssertions.forEach { assertion -> assertion.invoke() }
             }
         }
+    }
+
+    private fun createFieldAssertions(
+        expectedNode: JsonNode,
+        actualNode: JsonNode
+    ): List<() -> Unit> {
+        val acc = mutableListOf<() -> Unit>()
+        val actualValueMap = mutableMapOf<String, JsonNode>()
+        actualNode.forEachEntry { k, v -> actualValueMap[k] = v }
+
+        val expectedValueMap = mutableMapOf<String, JsonNode>()
+        expectedNode.forEachEntry { k, v -> expectedValueMap[k] = v }
+
+        val unexpectedFields = expectedValueMap.keys.minus(actualValueMap.keys).toMutableList()
+        unexpectedFields += actualValueMap.keys.minus(expectedValueMap.keys)
+
+        if (unexpectedFields.isNotEmpty()) {
+            return listOf({ fail("unexpected fields $unexpectedFields present") })
+        }
+        actualNode.forEachEntry { name, actual ->
+            val expected = expectedNode.at("/$name")
+            val metaAssertion = metaVariableAssertion(expected, actual)
+            acc += metaAssertion ?: { assertEquals(expected, actual) }
+        }
+        return acc.toList()
+    }
+
+    private fun metaVariableAssertion(expected: JsonNode, actual: JsonNode): (() -> Unit)? {
+        if (expected.isTextual && expected.asText() == "{{any}}") {
+            return { assertTrue(true) }
+        }
+        return null
     }
 
     private fun ensureThatPathPointsToFile(path: Path) {

--- a/lib/src/main/kotlin/com/github/bitknot_project/progressive_testing/data/Request.kt
+++ b/lib/src/main/kotlin/com/github/bitknot_project/progressive_testing/data/Request.kt
@@ -1,8 +1,10 @@
 package com.github.bitknot_project.progressive_testing.data
 
+import io.restassured.http.Header
+
 data class Request(
     var method: Method,
-    var headers: Map<String, String>,
+    var headers: List<Header>,
     var url: String,
     var body: String?
 ) {


### PR DESCRIPTION
The expected content field can use the `"{{any}}"` meta variable to accept any value as valid for a given field. More meta variable might be added in the future for the request execution or the response assertions.